### PR TITLE
Add foldAll to IEditSession

### DIFF
--- a/types/ace/index.d.ts
+++ b/types/ace/index.d.ts
@@ -474,7 +474,9 @@ declare namespace AceAjax {
         removeFold(arg: any): void;
 
         expandFold(arg: any): void;
-
+        
+        foldAll(startRow?: number, endRow?: number, depth?: number): void
+        
         unfold(arg1: any, arg2: boolean): void;
 
         screenToDocumentColumn(row: number, column: number): void;


### PR DESCRIPTION
I noticed the foldAll function does not appear in the IEditSession interface in index.d.ts
Not sure if there is a reason for it, but if there isn't one, could you merge this?